### PR TITLE
NBLMNT-371: Initialize .NET backend with DevLib packages

### DIFF
--- a/backend/dotnet/src/Maersk.DevBridge.Api/Maersk.DevBridge.Api.csproj
+++ b/backend/dotnet/src/Maersk.DevBridge.Api/Maersk.DevBridge.Api.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- API Documentation -->
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.14" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    
+    <!-- Authentication -->
+    <PackageReference Include="Microsoft.Identity.Web" Version="2.17.2" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="2.17.2" />
+    
+    <!-- Telemetry -->
+    <PackageReference Include="OpenTelemetry" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.2.0" />
+      <!-- DevLib Packages -->
+    <PackageReference Include="Maersk.DevLib.Configuration" Version="0.0.2" />
+    <PackageReference Include="Maersk.DevLib.PostgreSQL" Version="0.0.1" />
+    <PackageReference Include="Maersk.DevLib.Retina" Version="0.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/backend/dotnet/test/Maersk.DevBridge.Api.Tests/Maersk.DevBridge.Api.Tests.csproj
+++ b/backend/dotnet/test/Maersk.DevBridge.Api.Tests/Maersk.DevBridge.Api.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Maersk.DevBridge.Api\Maersk.DevBridge.Api.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="FluentAssertions" />
+    <Using Include="Moq" />
+    <Using Include="AutoFixture" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
### Changes
- Initialized .NET backend project structure
- Added required DevLib package references:
  - Maersk.DevLib.PostgreSQL v0.0.1
  - Maersk.DevLib.Retina v0.0.1
  - Maersk.DevLib.Configuration v0.0.2
- Added standard Maersk authentication using Microsoft.Identity.Web
- Added standard Maersk telemetry using OpenTelemetry with Azure App Insights
- Set up unit testing project with xUnit, Moq, FluentAssertions, and AutoFixture

### Testing
- Project builds successfully
- All package references are valid and using correct versions

### Related Issues
Resolves NBLMNT-371

### Follow-up Tasks
The following tasks should be created:
1. Configure auth, telemetry, and DevLib packages in Program.cs
2. Set up basic controllers and services
3. Configure database migrations